### PR TITLE
Fix record deletion updates

### DIFF
--- a/lib/app/modules/home/presenter/controller/record_controller.dart
+++ b/lib/app/modules/home/presenter/controller/record_controller.dart
@@ -89,9 +89,12 @@ abstract class RecordControllerBase with Store {
 
     await localDatabase.remove(params: params);
 
-    state.records.remove(record);
+    final updatedRecords = List<RecordEntity>.from(state.records)
+      ..remove(record);
 
-    final groupExists = state.records.any((e) => e.group == record.group);
+    emit(state.success(records: updatedRecords));
+
+    final groupExists = updatedRecords.any((e) => e.group == record.group);
 
     if (!groupExists) {
       emit(state.successDelete(record.group));

--- a/lib/app/modules/home/presenter/home_page.dart
+++ b/lib/app/modules/home/presenter/home_page.dart
@@ -106,10 +106,8 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
     final newTabCount = sortedGroupedRecords.length;
 
-    // Verificar se houve mudança no número de tabs
-    if (newTabCount > 0) {
-      _recreateTabController(newTabCount);
-    }
+    // Atualiza o TabController independente da quantidade de tabs
+    _recreateTabController(newTabCount);
   }
 
   void _recreateTabController(int newLength) {
@@ -118,6 +116,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
     // Remover listener e dispor controller anterior
     _tabController?.removeListener(_onTabChanged);
+    _tabController?.dispose();
 
     if (newLength > 0) {
       // Garantir que o índice seja válido para o novo length
@@ -137,11 +136,13 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
       if (sortedGroupedRecords.isNotEmpty) {
         selectedGroup = sortedGroupedRecords.keys.elementAt(_currentTabIndex);
       }
+    } else {
+      _tabController = null;
+    }
 
-      // Forçar rebuild
-      if (mounted) {
-        setState(() {});
-      }
+    // Forçar rebuild
+    if (mounted) {
+      setState(() {});
     }
   }
 
@@ -176,6 +177,10 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
       _updateTabController(
         sortedGroupedRecords.values.expand((e) => e).toList(),
       );
+
+      if (mounted) {
+        setState(() {});
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- update `deleteRecord` to emit updated list
- update tab handling to refresh after deletion and remove last tab

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687149ab8cb48322b891883e0348d7da