### PR TITLE
Add rating prompt

### DIFF
--- a/lib/app/di/dependency_injection.config.dart
+++ b/lib/app/di/dependency_injection.config.dart
@@ -24,10 +24,11 @@ import '../modules/config/presenter/services/in_app_purcashe_service.dart'
     as _i3;
 import '../modules/config/presenter/services/in_app_purcashe_service_imp.dart'
     as _i4;
-import '../modules/home/presenter/controller/record_controller.dart' as _i12;
-import '../modules/timer/controller/count_down_controller.dart' as _i14;
-import '../modules/timer/controller/timer_controller.dart' as _i13;
-import 'dependency_injection.dart' as _i15;
+import '../modules/home/presenter/controller/record_controller.dart' as _i13;
+import '../modules/timer/controller/count_down_controller.dart' as _i15;
+import '../modules/timer/controller/timer_controller.dart' as _i14;
+import '../shared/services/app_review_service.dart' as _i12;
+import 'dependency_injection.dart' as _i16;
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -51,16 +52,19 @@ extension GetItInjectableX on _i1.GetIt {
     gh.singleton<_i9.ConfigController>(
         () => _i9.ConfigController(gh<_i3.IInAppPurchaseService>()));
     gh.factory<_i10.ILocalDatabase>(() => _i11.IsarService(gh<_i7.Isar>()));
-    gh.singleton<_i12.RecordController>(
-        () => _i12.RecordController(localDatabase: gh<_i10.ILocalDatabase>()));
-    gh.factory<_i13.TimerController>(() => _i13.TimerController(
+    gh.factory<_i12.IAppReviewService>(
+        () => _i12.AppReviewService(gh<_i5.ILocalStorage>()));
+    gh.singleton<_i13.RecordController>(
+        () => _i13.RecordController(localDatabase: gh<_i10.ILocalDatabase>()));
+    gh.factory<_i14.TimerController>(() => _i14.TimerController(
           localDatabase: gh<_i10.ILocalDatabase>(),
-          recordController: gh<_i12.RecordController>(),
+          recordController: gh<_i13.RecordController>(),
+          appReviewService: gh<_i12.IAppReviewService>(),
         ));
-    gh.factory<_i14.CountDownController>(() =>
-        _i14.CountDownController(timerController: gh<_i13.TimerController>()));
+    gh.factory<_i15.CountDownController>(() =>
+        _i15.CountDownController(timerController: gh<_i14.TimerController>()));
     return this;
   }
 }
 
-class _$RegisterModule extends _i15.RegisterModule {}
+class _$RegisterModule extends _i16.RegisterModule {}

--- a/lib/app/modules/timer/controller/timer_controller.dart
+++ b/lib/app/modules/timer/controller/timer_controller.dart
@@ -8,6 +8,7 @@ import 'package:cuber_timer/app/core/data/clients/local_database/params/local_da
 import 'package:cuber_timer/app/modules/home/presenter/controller/record_controller.dart';
 import 'package:cuber_timer/app/modules/timer/controller/timer_states.dart';
 import 'package:cuber_timer/app/shared/utils/cube_types_list.dart';
+import 'package:cuber_timer/app/shared/services/app_review_service.dart';
 import 'package:flutter/material.dart';
 import 'package:injectable/injectable.dart';
 import 'package:mobx/mobx.dart';
@@ -21,10 +22,12 @@ class TimerController = TimerControllerBase with _$TimerController;
 abstract class TimerControllerBase with Store {
   final ILocalDatabase localDatabase;
   final RecordController recordController;
+  final IAppReviewService appReviewService;
 
   TimerControllerBase({
     required this.localDatabase,
     required this.recordController,
+    required this.appReviewService,
   });
 
   @observable
@@ -81,6 +84,7 @@ abstract class TimerControllerBase with Store {
         emit(BeatRecordTimerState());
         await Future.delayed(const Duration(microseconds: 100));
         emit(StopTimerState());
+        await appReviewService.registerBeatRecord();
       }
     }
 

--- a/lib/app/shared/services/app_review_service.dart
+++ b/lib/app/shared/services/app_review_service.dart
@@ -1,0 +1,38 @@
+import 'package:in_app_review/in_app_review.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../core/data/clients/shared_preferences/adapters/shared_params.dart';
+import '../../core/data/clients/shared_preferences/local_storage_interface.dart';
+
+abstract class IAppReviewService {
+  Future<void> registerBeatRecord();
+}
+
+@Injectable(as: IAppReviewService)
+class AppReviewService implements IAppReviewService {
+  static const String _counterKey = 'REVIEW_COUNTER';
+
+  final ILocalStorage localStorage;
+  final InAppReview _inAppReview;
+
+  AppReviewService(this.localStorage, [InAppReview? inAppReview])
+      : _inAppReview = inAppReview ?? InAppReview.instance;
+
+  @override
+  Future<void> registerBeatRecord() async {
+    final current = await localStorage.getData(_counterKey) as int? ?? 0;
+    final newCount = current + 1;
+
+    await localStorage.setData(
+      params: SharedParams(key: _counterKey, value: newCount),
+    );
+
+    if (newCount % 3 == 0) {
+      if (await _inAppReview.isAvailable()) {
+        await _inAppReview.requestReview();
+      } else {
+        await _inAppReview.openStoreListing();
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   injectable: ^2.4.4
   in_app_purchase: ^3.2.1
   super_sliver_list: ^0.4.1
+  in_app_review: ^2.0.8
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- prompt Play Store rating every third time the user beats their record
- wire rating service into dependency injection
- update TimerController to trigger rating
- add `in_app_review` dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875a72f88b48322becba0a5143b6c7a