### PR TITLE
Add rating reward system

### DIFF
--- a/lib/app/core/domain/entities/storage_keys.dart
+++ b/lib/app/core/domain/entities/storage_keys.dart
@@ -1,3 +1,4 @@
 class StorageKeys {
   static const String user = 'USER';
+  static const String adFreeExpiration = 'AD_FREE_EXPIRATION';
 }

--- a/lib/app/di/dependency_injection.config.dart
+++ b/lib/app/di/dependency_injection.config.dart
@@ -49,8 +49,11 @@ extension GetItInjectableX on _i1.GetIt {
       () => registerModule.prefs,
       preResolve: true,
     );
-    gh.singleton<_i9.ConfigController>(
-        () => _i9.ConfigController(gh<_i3.IInAppPurchaseService>()));
+    gh.singleton<_i9.ConfigController>(() =>
+        _i9.ConfigController(
+          gh<_i3.IInAppPurchaseService>(),
+          gh<_i10.IAppReviewService>(),
+        ));
     gh.factory<_i10.IAppReviewService>(
         () => _i10.AppReviewService(gh<_i5.ILocalStorage>()));
     gh.factory<_i11.ILocalDatabase>(() => _i12.IsarService(gh<_i7.Isar>()));

--- a/lib/app/modules/all_records_by_group/presenter/all_records_by_group_page.dart
+++ b/lib/app/modules/all_records_by_group/presenter/all_records_by_group_page.dart
@@ -127,7 +127,7 @@ class _AllRecordsByGroupPageState extends State<AllRecordsByGroupPage> {
 
               return Column(
                 children: [
-                  if (!Platform.isWindows && !configController.isAdRemoved) ...[
+                  if (!Platform.isWindows && !configController.adsDisabled) ...[
                     if (isAdLoaded)
                       SizedBox(
                         height: myBanner.size.height.toDouble(),
@@ -177,7 +177,7 @@ class _AllRecordsByGroupPageState extends State<AllRecordsByGroupPage> {
                     ),
                   ),
                   const Divider(),
-                  if (!Platform.isWindows && !configController.isAdRemoved) ...[
+                  if (!Platform.isWindows && !configController.adsDisabled) ...[
                     if (isAdLoadedBottom)
                       SizedBox(
                         height: myBannerBottom.size.height.toDouble(),

--- a/lib/app/modules/config/presenter/config_page.dart
+++ b/lib/app/modules/config/presenter/config_page.dart
@@ -59,7 +59,7 @@ class _ConfigPageState extends State<ConfigPage> {
             if (state is AdRemovalSuccessState) {
               return _buildConfigOptions(
                 context,
-                configController.isAdRemoved,
+                configController.adsDisabled,
                 'Anúncios removidos com sucesso!',
               );
             }
@@ -77,7 +77,7 @@ class _ConfigPageState extends State<ConfigPage> {
 
             // Default (Initial) State
             return _buildConfigOptions(
-                context, configController.isAdRemoved, '');
+                context, configController.adsDisabled, '');
           },
         ),
       ),
@@ -86,7 +86,7 @@ class _ConfigPageState extends State<ConfigPage> {
 
   // Função para construir as opções de configuração
   Widget _buildConfigOptions(
-      BuildContext context, bool adsRemoved, String message) {
+      BuildContext context, bool adsDisabled, String message) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -99,8 +99,9 @@ class _ConfigPageState extends State<ConfigPage> {
         ],
         ListTile(
           title: const Text('Remover Anúncios'),
-          subtitle: Text(adsRemoved ? 'Anúncios removidos' : 'Anúncios ativos'),
-          trailing: adsRemoved
+          subtitle: Text(
+              adsDisabled ? 'Anúncios removidos' : 'Anúncios ativos'),
+          trailing: adsDisabled
               ? const Icon(Icons.check_circle, color: Colors.green)
               : ElevatedButton(
                   onPressed: configController.state is AdRemovalInProgressState

--- a/lib/app/modules/config/presenter/controller/config_controller.dart
+++ b/lib/app/modules/config/presenter/controller/config_controller.dart
@@ -2,6 +2,7 @@ import 'package:injectable/injectable.dart';
 import 'package:mobx/mobx.dart';
 
 import '../services/in_app_purcashe_service.dart';
+import '../../../shared/services/app_review_service.dart';
 import 'config_states.dart';
 
 part 'config_controller.g.dart'; // Código gerado pelo MobX
@@ -11,14 +12,26 @@ class ConfigController = _ConfigControllerBase with _$ConfigController;
 
 abstract class _ConfigControllerBase with Store {
   final IInAppPurchaseService inAppPurchaseService;
+  final IAppReviewService appReviewService;
 
-  _ConfigControllerBase(this.inAppPurchaseService);
+  _ConfigControllerBase(this.inAppPurchaseService, this.appReviewService);
 
   @observable
   ConfigStates state = ConfigInitialState();
 
   @observable
   bool isAdRemoved = false;
+
+  @observable
+  bool isRewardActive = false;
+
+  @computed
+  bool get adsDisabled => isAdRemoved || isRewardActive;
+
+  @action
+  Future<void> checkAdFreeStatus() async {
+    isRewardActive = await appReviewService.isRewardActive();
+  }
 
   @action
   Future<void> removeAds() async {

--- a/lib/app/modules/config/presenter/controller/config_controller.g.dart
+++ b/lib/app/modules/config/presenter/controller/config_controller.g.dart
@@ -41,6 +41,36 @@ mixin _$ConfigController on _ConfigControllerBase, Store {
     });
   }
 
+  late final _$isRewardActiveAtom =
+      Atom(name: '_ConfigControllerBase.isRewardActive', context: context);
+
+  @override
+  bool get isRewardActive {
+    _$isRewardActiveAtom.reportRead();
+    return super.isRewardActive;
+  }
+
+  @override
+  set isRewardActive(bool value) {
+    _$isRewardActiveAtom.reportWrite(value, super.isRewardActive, () {
+      super.isRewardActive = value;
+    });
+  }
+
+  late final _$checkAdFreeStatusAsyncAction =
+      AsyncAction('_ConfigControllerBase.checkAdFreeStatus', context: context);
+
+  @override
+  Future<void> checkAdFreeStatus() {
+    return _$checkAdFreeStatusAsyncAction.run(() => super.checkAdFreeStatus());
+  }
+
+  late final _$adsDisabledComputed =
+      Computed<bool>(() => super.adsDisabled, name: '_ConfigControllerBase.adsDisabled');
+
+  @override
+  bool get adsDisabled => _$adsDisabledComputed.value;
+
   late final _$removeAdsAsyncAction =
       AsyncAction('_ConfigControllerBase.removeAds', context: context);
 
@@ -53,7 +83,9 @@ mixin _$ConfigController on _ConfigControllerBase, Store {
   String toString() {
     return '''
 state: ${state},
-isAdRemoved: ${isAdRemoved}
+isAdRemoved: ${isAdRemoved},
+isRewardActive: ${isRewardActive}
+adsDisabled: ${adsDisabled}
     ''';
   }
 }

--- a/lib/app/modules/home/presenter/home_page.dart
+++ b/lib/app/modules/home/presenter/home_page.dart
@@ -253,7 +253,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   }
 
   Future<void> _showInterstitialAd() async {
-    if (_interstitialAd == null || configController.isAdRemoved) {
+    if (_interstitialAd == null || configController.adsDisabled) {
       await Navigator.pushReplacementNamed(context, NamedRoutes.timer.route);
       await getFiveRecordsByGroup();
       if (!Platform.isWindows) {
@@ -339,7 +339,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                     children: [
                       // Banners...
                       if (!Platform.isWindows &&
-                          !configController.isAdRemoved) ...[
+                          !configController.adsDisabled) ...[
                         if (isTopAdLoaded)
                           SizedBox(
                             height: myBanner.size.height.toDouble(),
@@ -568,7 +568,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             onPressed: _showInterstitialAd,
           ),
           const SizedBox(height: 15),
-          if (!Platform.isWindows && !configController.isAdRemoved) ...[
+          if (!Platform.isWindows && !configController.adsDisabled) ...[
             if (isBottomAdLoaded && state.records.isNotEmpty)
               SizedBox(
                 height: myBottmBanner.size.height.toDouble(),

--- a/lib/app/modules/splash/presenter/splash_page.dart
+++ b/lib/app/modules/splash/presenter/splash_page.dart
@@ -51,6 +51,8 @@ class _SplashPageState extends State<SplashPage> {
       configController.isAdRemoved = false;
     });
 
+    configController.checkAdFreeStatus();
+
     _init();
   }
 

--- a/lib/app/modules/timer/presenter/timer_page.dart
+++ b/lib/app/modules/timer/presenter/timer_page.dart
@@ -139,7 +139,7 @@ class _TimerPageState extends State<TimerPage> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
-                if (!Platform.isWindows && !configController.isAdRemoved) ...[
+                if (!Platform.isWindows && !configController.adsDisabled) ...[
                   isAdLoaded
                       ? Column(
                           children: [

--- a/lib/app/modules/timer/presenter/widgets/list_scrambles_page.dart
+++ b/lib/app/modules/timer/presenter/widgets/list_scrambles_page.dart
@@ -77,7 +77,7 @@ class _ListScramblesPageState extends State<ListScramblesPage> {
       body: Column(
         children: [
           const SizedBox(height: 10),
-          if (!Platform.isWindows && !configController.isAdRemoved) ...[
+          if (!Platform.isWindows && !configController.adsDisabled) ...[
             isAdLoaded
                 ? Column(
                     children: [


### PR DESCRIPTION
## Summary
- store expiration of ad-free rewards in storage keys
- reward users with 7 days ad-free after rating the app
- manage ad-disable state in config controller
- wire config controller through DI for review service
- hide ads when reward is active across pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d9c220a1c8322a87c5de113d85f30