### PR TITLE
Fix PurchaseService integration

### DIFF
--- a/lib/app/di/dependency_injection.config.dart
+++ b/lib/app/di/dependency_injection.config.dart
@@ -20,9 +20,7 @@ import '../core/data/clients/shared_preferences/local_storage_interface.dart'
 import '../core/data/clients/shared_preferences/shared_preferences_service.dart'
     as _i4;
 import '../modules/config/presenter/controller/config_controller.dart' as _i14;
-import '../modules/config/presenter/services/subscription_service.dart' as _i5;
-import '../modules/config/presenter/services/subscription_service_imp.dart'
-    as _i6;
+import '../modules/config/presenter/services/purchase_service.dart' as _i5;
 import '../modules/home/presenter/controller/record_controller.dart' as _i12;
 import '../modules/timer/controller/count_down_controller.dart' as _i15;
 import '../modules/timer/controller/timer_controller.dart' as _i13;
@@ -42,7 +40,7 @@ extension GetItInjectableX on _i1.GetIt {
     );
     final registerModule = _$RegisterModule();
     gh.factory<_i3.ILocalStorage>(() => _i4.SharedPreferencesService());
-    gh.factory<_i5.ISubscriptionService>(() => _i6.SubscriptionServiceImp());
+    gh.singleton<_i5.PurchaseService>(() => _i5.PurchaseService());
     gh.factory<_i7.Isar>(() => registerModule.isar);
     await gh.factoryAsync<_i8.SharedPreferences>(
       () => registerModule.prefs,
@@ -59,7 +57,7 @@ extension GetItInjectableX on _i1.GetIt {
           appReviewService: gh<_i9.IAppReviewService>(),
         ));
     gh.singleton<_i14.ConfigController>(() => _i14.ConfigController(
-          gh<_i5.ISubscriptionService>(),
+          gh<_i5.PurchaseService>(),
           gh<_i9.IAppReviewService>(),
         ));
     gh.factory<_i15.CountDownController>(() =>

--- a/lib/app/di/dependency_injection.dart
+++ b/lib/app/di/dependency_injection.dart
@@ -8,6 +8,7 @@ import 'package:injectable/injectable.dart';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../modules/config/presenter/services/purchase_service.dart';
 
 import '../core/data/clients/local_database/schemas/record.dart';
 import 'dependency_injection.config.dart';
@@ -25,6 +26,8 @@ Future<void> configureDependencies() async {
   await _initIsar();
 
   await getIt.init();
+
+  await getIt<PurchaseService>().init();
 
   await _checkRecordsWithoutGroupAndSetGroupDefault();
   await _insertDebugRecords();

--- a/lib/app/modules/config/presenter/config_page.dart
+++ b/lib/app/modules/config/presenter/config_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 
+import '../../../core/domain/entities/subscription_plan.dart';
+
 import '../../../di/dependency_injection.dart';
 import 'controller/config_controller.dart';
 
@@ -41,9 +43,27 @@ class _ConfigPageState extends State<ConfigPage> {
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
                 ),
-              _buildPlanCard('Plano Semanal', '200,00', onTap: () {}),
-              _buildPlanCard('Plano Mensal', '350,00', onTap: () {}),
-              _buildPlanCard('Plano Anual', '500,00', onTap: () {}),
+              _buildPlanCard(
+                'Plano Semanal',
+                configController
+                    .priceFor(SubscriptionPlan.weekly),
+                onTap: () =>
+                    configController.buyPlan(SubscriptionPlan.weekly),
+              ),
+              _buildPlanCard(
+                'Plano Mensal',
+                configController
+                    .priceFor(SubscriptionPlan.monthly),
+                onTap: () =>
+                    configController.buyPlan(SubscriptionPlan.monthly),
+              ),
+              _buildPlanCard(
+                'Plano Anual',
+                configController
+                    .priceFor(SubscriptionPlan.annual),
+                onTap: () =>
+                    configController.buyPlan(SubscriptionPlan.annual),
+              ),
             ],
           ),
         ),
@@ -51,7 +71,8 @@ class _ConfigPageState extends State<ConfigPage> {
     );
   }
 
-  Widget _buildPlanCard(String title, String price, {required VoidCallback onTap}) {
+  Widget _buildPlanCard(String title, String price,
+      {required VoidCallback onTap}) {
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8),
       child: ListTile(
@@ -59,7 +80,7 @@ class _ConfigPageState extends State<ConfigPage> {
           title,
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
-        subtitle: Text('R\$ $price de 350,00'),
+        subtitle: Text('R\$ $price'),
         trailing: ElevatedButton(
           onPressed: onTap,
           child: const Text('Assinar'),

--- a/lib/app/modules/config/presenter/controller/config_controller.dart
+++ b/lib/app/modules/config/presenter/controller/config_controller.dart
@@ -4,7 +4,7 @@ import 'package:injectable/injectable.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../../../core/constants/constants.dart';
-import '../services/subscription_service.dart';
+import '../../../../core/domain/entities/subscription_plan.dart';
 import 'config_states.dart';
 
 part 'config_controller.g.dart'; // Código gerado pelo MobX
@@ -13,10 +13,10 @@ part 'config_controller.g.dart'; // Código gerado pelo MobX
 class ConfigController = _ConfigControllerBase with _$ConfigController;
 
 abstract class _ConfigControllerBase with Store {
-  final PurchaseService subscriptionService;
+  final PurchaseService purchaseService;
   final IAppReviewService appReviewService;
 
-  _ConfigControllerBase(this.subscriptionService, this.appReviewService);
+  _ConfigControllerBase(this.purchaseService, this.appReviewService);
 
   @observable
   ConfigStates state = ConfigInitialState();
@@ -30,6 +30,10 @@ abstract class _ConfigControllerBase with Store {
   @computed
   bool get adsDisabled => isPremium || isRewardActive;
 
+  String priceFor(SubscriptionPlan plan) => purchaseService.priceFor(plan);
+
+  Future<void> buyPlan(SubscriptionPlan plan) => purchaseService.buy(plan);
+
   @action
   Future<void> checkAdFreeStatus() async {
     isRewardActive = await appReviewService.isRewardActive();
@@ -37,9 +41,7 @@ abstract class _ConfigControllerBase with Store {
 
   @action
   Future<void> fetchSubscriptions() async {
-    final subs = await subscriptionService.getUserSubscriptions();
-    isPremium = subs.contains(weeklyPlanId) ||
-        subs.contains(monthlyPlanId) ||
-        subs.contains(annualPlanId);
+    await purchaseService.init();
+    isPremium = purchaseService.isPremium;
   }
 }


### PR DESCRIPTION
## Summary
- replace old subscription service usage with `PurchaseService`
- show plan prices and actions in `ConfigPage`
- initialize `PurchaseService` on startup via DI
- update generated dependency injection configuration

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bcbee6db083228f2c65a775990336