### PR TITLE
feat: add global translate support

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -13,6 +13,7 @@ home_page:
   formatDateTime: "MMMM dd, yyyy 'at' h:mm:ss a"
   tagDateTime: en_us
   buttonMoreRecords: More Records
+  error_title: Oops...
 
 timer_page:
   title_appbar: Stopwatch
@@ -30,3 +31,12 @@ timer_page:
   textButtonListScrambles: Click here to see the scrambles list
   titleAppbarScramblesList: Scrambles List
   textDescriptionScrambleSelected: Click on a scramble to highlight it
+  alert_title_congrats: Woohoo
+
+config_page:
+  title_appbar: Settings
+  premium_message: You are Premium. Thanks for supporting!
+  plan_weekly: Weekly Plan
+  plan_monthly: Monthly Plan
+  plan_annual: Annual Plan
+  button_subscribe: Subscribe

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -13,6 +13,7 @@ home_page:
   formatDateTime: "dd 'de' MMMM 'de' yyyy "as" 'hh:mm:ss a"
   tagDateTime: pt_br
   buttonMoreRecords: Mais Recordes
+  error_title: Opss...
 
 timer_page:
   title_appbar: Cronômetro
@@ -30,3 +31,12 @@ timer_page:
   textButtonListScrambles: Clique aqui para ver a lista de embaralhamentos
   titleAppbarScramblesList: Lista de Embaralhamentos
   textDescriptionScrambleSelected: Clique em um embaralhamento para destacá-lo
+  alert_title_congrats: Uhuu
+
+config_page:
+  title_appbar: Configurações
+  premium_message: Você é Premium. Obrigado por apoiar!
+  plan_weekly: Plano Semanal
+  plan_monthly: Plano Mensal
+  plan_annual: Plano Anual
+  button_subscribe: Assinar

--- a/lib/app/app_widget.dart
+++ b/lib/app/app_widget.dart
@@ -2,6 +2,7 @@ import 'package:bot_toast/bot_toast.dart';
 import 'package:cuber_timer/app/core/domain/entities/app_language.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 
 import 'core/domain/entities/named_routes.dart';
 import 'core/routes/app_routes.dart';
@@ -21,7 +22,7 @@ class _AppWidgetState extends State<AppWidget> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Cube Timer',
+      title: translate('splash_page.title'),
       debugShowCheckedModeBanner: false,
       navigatorKey: GlobalContext.navigatorKey,
       theme: lightThemeApp,

--- a/lib/app/modules/all_records_by_group/presenter/all_records_by_group_page.dart
+++ b/lib/app/modules/all_records_by_group/presenter/all_records_by_group_page.dart
@@ -12,6 +12,7 @@ import '../../config/presenter/controller/config_controller.dart';
 import '../../home/presenter/controller/record_controller.dart';
 import '../../home/presenter/controller/record_states.dart';
 import '../../home/presenter/widgets/card_record_widget.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 
 class AllRecordsByGroupPage extends StatefulWidget {
   const AllRecordsByGroupPage({super.key});
@@ -95,7 +96,7 @@ class _AllRecordsByGroupPageState extends State<AllRecordsByGroupPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          context.translate.timerPage.titleAppBarMoreRecords,
+          translate('timer_page.title_appbar_more_records'),
         ),
       ),
       body: Padding(
@@ -117,7 +118,7 @@ class _AllRecordsByGroupPageState extends State<AllRecordsByGroupPage> {
 
               if (records.isEmpty) {
                 return Center(
-                  child: Text(context.translate.homePage.listEmpty),
+                  child: Text(translate('home_page.list_empty')),
                 );
               }
 
@@ -134,8 +135,8 @@ class _AllRecordsByGroupPageState extends State<AllRecordsByGroupPage> {
                   ],
                   Text(
                     groupArg == null
-                        ? context.translate.timerPage.textGroupByModelLoading
-                        : '${context.translate.timerPage.textGroupByModel}: $groupArg',
+                        ? translate('timer_page.textGroupByModelLoading')
+                        : '${translate('timer_page.textGroupByModel')}: $groupArg',
                     style: const TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.bold,
@@ -186,7 +187,7 @@ class _AllRecordsByGroupPageState extends State<AllRecordsByGroupPage> {
             }
 
             return Center(
-              child: Text(context.translate.homePage.listEmpty),
+              child: Text(translate('home_page.list_empty')),
             );
           },
         ),

--- a/lib/app/modules/config/presenter/config_page.dart
+++ b/lib/app/modules/config/presenter/config_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import '../../../core/domain/entities/subscription_plan.dart';
 import '../../../di/dependency_injection.dart';
 import 'controller/config_controller.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 
 class ConfigPage extends StatefulWidget {
   const ConfigPage({super.key});
@@ -26,7 +27,7 @@ class _ConfigPageState extends State<ConfigPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Configurações'),
+        title: Text(translate('config_page.title_appbar')),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -35,25 +36,25 @@ class _ConfigPageState extends State<ConfigPage> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               if (configController.isPremium)
-                const Padding(
-                  padding: EdgeInsets.only(bottom: 20),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 20),
                   child: Text(
-                    'Você é Premium. Obrigado por apoiar!',
-                    style: TextStyle(fontWeight: FontWeight.bold),
+                    translate('config_page.premium_message'),
+                    style: const TextStyle(fontWeight: FontWeight.bold),
                   ),
                 ),
               _buildPlanCard(
-                'Plano Semanal',
+                translate('config_page.plan_weekly'),
                 configController.priceFor(SubscriptionPlan.weekly),
                 onTap: () => configController.buyPlan(SubscriptionPlan.weekly),
               ),
               _buildPlanCard(
-                'Plano Mensal',
+                translate('config_page.plan_monthly'),
                 configController.priceFor(SubscriptionPlan.monthly),
                 onTap: () => configController.buyPlan(SubscriptionPlan.monthly),
               ),
               _buildPlanCard(
-                'Plano Anual',
+                translate('config_page.plan_annual'),
                 configController.priceFor(SubscriptionPlan.annual),
                 onTap: () => configController.buyPlan(SubscriptionPlan.annual),
               ),
@@ -76,7 +77,7 @@ class _ConfigPageState extends State<ConfigPage> {
         subtitle: Text(price),
         trailing: ElevatedButton(
           onPressed: onTap,
-          child: const Text('Assinar'),
+          child: Text(translate('config_page.button_subscribe')),
         ),
       ),
     );

--- a/lib/app/modules/home/presenter/home_page.dart
+++ b/lib/app/modules/home/presenter/home_page.dart
@@ -15,6 +15,7 @@ import 'package:cuber_timer/app/shared/components/my_elevated_button_widget.dart
 import 'package:cuber_timer/app/shared/components/my_snackbar.dart';
 import 'package:cuber_timer/app/shared/components/no_data_widget.dart';
 import 'package:cuber_timer/app/shared/utils/cube_types_list.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
@@ -63,7 +64,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
       if (state is ErrorRecordState) {
         MySnackBar(
-          title: 'Opss...',
+          title: translate('home_page.error_title'),
           message: state.message,
           type: TypeSnack.error,
         );
@@ -260,7 +261,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               Observer(builder: (context) {
                 if (_tabController == null || sortedGroupedRecords.isEmpty) {
                   return NoDataWidget(
-                    text: context.translate.homePage.listEmpty,
+                    text: translate('home_page.list_empty'),
                   );
                 }
 
@@ -273,7 +274,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                     children: [
                       const MyCircularProgressWidget(),
                       Text(
-                        context.translate.homePage.textLoading,
+                        translate('home_page.text_loading'),
                         style: context.textTheme.bodyLarge,
                       ),
                     ],
@@ -284,7 +285,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
                 if (records.isEmpty) {
                   return NoDataWidget(
-                    text: context.translate.homePage.listEmpty,
+                    text: translate('home_page.list_empty'),
                   );
                 }
 
@@ -317,7 +318,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                               ),
                             ),
                             child: Text(
-                              context.translate.homePage.titleList,
+                              translate('home_page.title_list'),
                               style: context.textTheme.bodyLarge
                                   ?.copyWith(fontWeight: FontWeight.bold),
                             ),
@@ -432,7 +433,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                           await getFiveRecordsByGroup();
                         },
                         child: Text(
-                          context.translate.homePage.buttonMoreRecords,
+                          translate('home_page.buttonMoreRecords'),
                         ),
                       ),
                     ),
@@ -472,7 +473,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               ),
             ),
             child: Text(
-              context.translate.homePage.titleAvg,
+              translate('home_page.title_avg'),
               style: context.textTheme.bodyLarge?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -484,17 +485,17 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             _buildAvgColumn(
-              context.translate.homePage.best,
+              translate('home_page.best'),
               recordController.bestTime(selectedGroup),
               Colors.amber,
             ),
             _buildAvgColumn(
-              context.translate.homePage.avg5,
+              translate('home_page.avg_5'),
               recordController.avgFive(selectedGroup),
               Colors.green,
             ),
             _buildAvgColumn(
-              context.translate.homePage.avg12,
+              translate('home_page.avg_12'),
               recordController.avgTwelve(selectedGroup),
               Colors.blue,
             ),
@@ -519,7 +520,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
         children: [
           MyElevatedButtonWidget(
             width: context.screenWidth * .4,
-            label: Text(context.translate.homePage.buttonStart),
+            label: Text(translate('home_page.button_start')),
             onPressed: _showInterstitialAd,
           ),
           const SizedBox(height: 15),

--- a/lib/app/modules/home/presenter/widgets/card_record_widget.dart
+++ b/lib/app/modules/home/presenter/widgets/card_record_widget.dart
@@ -72,7 +72,7 @@ class _CardRecordWidgetState extends State<CardRecordWidget> {
         ),
       ),
       subtitle: Text(
-        widget.recordEntity.createdAt.formatDateTime(context),
+        widget.recordEntity.createdAt.formatDateTime(),
       ),
       trailing: IconButton(
         onPressed: () {

--- a/lib/app/modules/splash/presenter/splash_page.dart
+++ b/lib/app/modules/splash/presenter/splash_page.dart
@@ -1,5 +1,6 @@
 import 'package:cuber_timer/app/core/constants/constants.dart';
 import 'package:flutter/material.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 
 import '../../../core/domain/entities/named_routes.dart';
 import '../../../di/dependency_injection.dart';
@@ -40,7 +41,7 @@ class _SplashPageState extends State<SplashPage> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
-            context.translate.splashPage.title,
+            translate('splash_page.title'),
             style: context.textTheme.bodyLarge?.copyWith(
               fontWeight: FontWeight.bold,
               fontSize: 25,

--- a/lib/app/modules/timer/presenter/timer_page.dart
+++ b/lib/app/modules/timer/presenter/timer_page.dart
@@ -18,6 +18,7 @@ import '../controller/timer_controller.dart';
 import '../controller/timer_states.dart';
 import 'widgets/alert_congrats_beat_record_widget.dart';
 import 'widgets/list_scrambles_page.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 
 class TimerPage extends StatefulWidget {
   const TimerPage({super.key});
@@ -85,7 +86,7 @@ class _TimerPageState extends State<TimerPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(context.translate.timerPage.titleAppBar),
+        title: Text(translate('timer_page.title_appbar')),
         leading: BackButton(
           onPressed: () {
             Navigator.pushNamedAndRemoveUntil(
@@ -179,8 +180,7 @@ class _TimerPageState extends State<TimerPage> {
                                           child: Column(
                                             children: [
                                               Text(
-                                                context.translate.timerPage
-                                                    .titleScrambles,
+                                                translate('timer_page.title_scrambles'),
                                                 style: context
                                                     .textTheme.bodyLarge
                                                     ?.copyWith(
@@ -203,14 +203,10 @@ class _TimerPageState extends State<TimerPage> {
                                                     ),
                                                   );
                                                 },
-                                                child: Text(context
-                                                    .translate
-                                                    .timerPage
-                                                    .textButtonListScrambles),
+                                                child: Text(translate('timer_page.textButtonListScrambles')),
                                               ),
                                               // Text(
-                                              //   context.translate.timerPage
-                                              //       .textHowToChangeScramble,
+                                              //   translate('timer_page.text_description_how_to_change_scrambles'),
                                               //   style:
                                               //       context.textTheme.bodySmall,
                                               // ),
@@ -233,8 +229,7 @@ class _TimerPageState extends State<TimerPage> {
                                                 MainAxisAlignment.spaceBetween,
                                             children: [
                                               Text(
-                                                context.translate.timerPage
-                                                    .textDescriptionLabelGroup,
+                                                translate('timer_page.text_description_label_group'),
                                                 style: context
                                                     .textTheme.bodyLarge
                                                     ?.copyWith(
@@ -285,8 +280,7 @@ class _TimerPageState extends State<TimerPage> {
                                       ),
                                     ),
                                     Text(
-                                      context
-                                          .translate.timerPage.textHelpToUseApp,
+                                      translate('timer_page.text_help_to_use_app'),
                                       textAlign: TextAlign.center,
                                     ),
                                   ],
@@ -326,8 +320,7 @@ class _TimerPageState extends State<TimerPage> {
                                       data > 0 && (state is StopTimerState),
                                   child: MyElevatedButtonWidget(
                                     label: Text(
-                                      context.translate.timerPage
-                                          .textButtonNewStopwatch,
+                                      translate('timer_page.text_button_new_stop_watch'),
                                     ),
                                     onPressed: () {
                                       timerController.resetTimer();
@@ -342,8 +335,7 @@ class _TimerPageState extends State<TimerPage> {
                                       data > 0 && (state is StartTimerState),
                                   child: Center(
                                     child: Text(
-                                      context.translate.timerPage
-                                          .textHelpToStopTimer,
+                                      translate('timer_page.text_help_to_stop_timer'),
                                       style: context.textTheme.bodyLarge,
                                     ),
                                   ),

--- a/lib/app/modules/timer/presenter/widgets/alert_congrats_beat_record_widget.dart
+++ b/lib/app/modules/timer/presenter/widgets/alert_congrats_beat_record_widget.dart
@@ -3,6 +3,7 @@ import 'package:lottie/lottie.dart';
 
 import '../../../../core/constants/constants.dart';
 import '../../../../shared/components/my_elevated_button_widget.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 
 class AlertCongratsBeatRecordWidget extends StatelessWidget {
   const AlertCongratsBeatRecordWidget({super.key});
@@ -19,7 +20,7 @@ class AlertCongratsBeatRecordWidget extends StatelessWidget {
         children: [
           Center(
             child: Text(
-              'Woouu',
+              translate('timer_page.alert_title_congrats'),
               style: context.textTheme.titleLarge?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -28,7 +29,7 @@ class AlertCongratsBeatRecordWidget extends StatelessWidget {
           const Divider(),
           Lottie.asset('assets/images/congrats.json', width: 200),
           Text(
-            context.translate.timerPage.textBeatRecord,
+            translate('timer_page.text_beat_record'),
             textAlign: TextAlign.center,
             style: context.textTheme.bodyLarge?.copyWith(
               fontWeight: FontWeight.bold,
@@ -39,7 +40,7 @@ class AlertCongratsBeatRecordWidget extends StatelessWidget {
             children: [
               Expanded(
                 child: MyElevatedButtonWidget(
-                  label: Text(context.translate.timerPage.textButtonBeatRecord),
+                  label: Text(translate('timer_page.text_button_beat_record')),
                   onPressed: () {
                     Navigator.of(context).pop('dialog');
                   },

--- a/lib/app/modules/timer/presenter/widgets/list_scrambles_page.dart
+++ b/lib/app/modules/timer/presenter/widgets/list_scrambles_page.dart
@@ -9,6 +9,7 @@ import '../../../../core/constants/constants.dart';
 import '../../../../di/dependency_injection.dart';
 import '../../../config/presenter/controller/config_controller.dart';
 import 'card_scramble_widget.dart';
+import 'package:cuber_timer/app/shared/translate/translate.dart';
 
 class ListScramblesPage extends StatefulWidget {
   final PageController pageController;
@@ -64,7 +65,7 @@ class _ListScramblesPageState extends State<ListScramblesPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(context.translate.timerPage.titleAppbarScramblesList),
+        title: Text(translate('timer_page.titleAppbarScramblesList')),
         centerTitle: true,
       ),
       body: Column(
@@ -85,7 +86,7 @@ class _ListScramblesPageState extends State<ListScramblesPage> {
                 : const SizedBox(height: 10),
           ],
           Text(
-            context.translate.timerPage.textDescriptionScrambleSelected,
+            translate('timer_page.textDescriptionScrambleSelected'),
             style: context.textTheme.bodyMedium?.copyWith(
               fontSize: 16,
               fontWeight: FontWeight.w500,

--- a/lib/app/shared/utils/formatters.dart
+++ b/lib/app/shared/utils/formatters.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 
-import '../../core/constants/constants.dart';
+import '../translate/translate.dart';
 
 class Formatters {}
 
@@ -100,10 +100,10 @@ extension AnoMesDia on DateTime {
 }
 
 extension FormatDateTime on DateTime {
-  String formatDateTime(BuildContext context) {
+  String formatDateTime() {
     final format = DateFormat(
-      context.translate.homePage.formatDateTime,
-      context.translate.homePage.tagDateTime,
+      translate('home_page.formatDateTime'),
+      translate('home_page.tagDateTime'),
     );
 
     return format.format(this);


### PR DESCRIPTION
## Summary
- replace legacy `context.translate` calls with new `translate` helper
- add missing i18n entries for config page and error messages
- simplify date formatter to use global translation values

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688fedd6837c8322961176e33279e1ee