### PR TITLE
feat: add subscription button

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -14,6 +14,8 @@ home_page:
   tagDateTime: en_us
   buttonMoreRecords: More Records
   error_title: Oops...
+  button_subscribe: Subscribe
+  button_upgrade: Upgrade
 
 timer_page:
   title_appbar: Stopwatch

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -14,6 +14,8 @@ home_page:
   tagDateTime: pt_br
   buttonMoreRecords: Mais Recordes
   error_title: Opss...
+  button_subscribe: Assinar
+  button_upgrade: Upgrade
 
 timer_page:
   title_appbar: Cronômetro

--- a/lib/app/modules/home/presenter/home_page.dart
+++ b/lib/app/modules/home/presenter/home_page.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import 'package:cuber_timer/app/core/constants/constants.dart';
 import 'package:cuber_timer/app/core/data/clients/local_database/schemas/record.dart';
 import 'package:cuber_timer/app/core/domain/entities/named_routes.dart';
+import 'package:cuber_timer/app/core/domain/entities/app_global.dart';
+import 'package:cuber_timer/app/core/domain/entities/subscription_plan.dart';
 import 'package:cuber_timer/app/di/dependency_injection.dart';
 import 'package:cuber_timer/app/modules/config/presenter/controller/config_controller.dart';
 import 'package:cuber_timer/app/modules/home/presenter/controller/record_controller.dart';
@@ -289,6 +291,9 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                   );
                 }
 
+                final Widget? subscriptionButton =
+                    _buildSubscriptionButton();
+
                 return Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -323,11 +328,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                                   ?.copyWith(fontWeight: FontWeight.bold),
                             ),
                           ),
-                          IconButton(
-                            onPressed: () => Navigator.pushNamed(
-                                context, NamedRoutes.config.route),
-                            icon: const Icon(Icons.settings),
-                          ),
+                          if (subscriptionButton != null) subscriptionButton,
                         ],
                       ),
 
@@ -346,6 +347,27 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
           ),
         ),
       ),
+    );
+  }
+
+  Widget? _buildSubscriptionButton() {
+    final SubscriptionPlan plan = AppGlobal.instance.plan;
+
+    if (plan == SubscriptionPlan.annual) {
+      return null;
+    }
+
+    final bool isUpgrade =
+        plan == SubscriptionPlan.weekly || plan == SubscriptionPlan.monthly;
+
+    final String label = isUpgrade
+        ? translate('home_page.button_upgrade')
+        : translate('home_page.button_subscribe');
+
+    return TextButton(
+      onPressed: () =>
+          Navigator.pushNamed(context, NamedRoutes.config.route),
+      child: Text(label),
     );
   }
 


### PR DESCRIPTION
## Summary
- replace settings icon with dynamic subscribe/upgrade button depending on plan
- add Portuguese and English translations for subscription labels

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff522596883229fbfb6a6f1f4ca4d