### PR TITLE
refactor: remover isRewardActive

### DIFF
--- a/lib/app/core/domain/entities/storage_keys.dart
+++ b/lib/app/core/domain/entities/storage_keys.dart
@@ -1,4 +1,3 @@
 class StorageKeys {
   static const String user = 'USER';
-  static const String adFreeExpiration = 'AD_FREE_EXPIRATION';
 }

--- a/lib/app/di/dependency_injection.config.dart
+++ b/lib/app/di/dependency_injection.config.dart
@@ -58,10 +58,10 @@ extension GetItInjectableX on _i1.GetIt {
           recordController: gh<_i12.RecordController>(),
           appReviewService: gh<_i9.IAppReviewService>(),
         ));
-    gh.singleton<_i14.ConfigController>(() => _i14.ConfigController(
-          gh<_i7.PurchaseService>(),
-          gh<_i9.IAppReviewService>(),
-        ));
+    gh.singleton<_i14.ConfigController>(
+        () => _i14.ConfigController(
+              gh<_i7.PurchaseService>(),
+            ));
     gh.factory<_i15.CountDownController>(() =>
         _i15.CountDownController(timerController: gh<_i13.TimerController>()));
     return this;

--- a/lib/app/modules/config/presenter/config_page.dart
+++ b/lib/app/modules/config/presenter/config_page.dart
@@ -20,7 +20,6 @@ class _ConfigPageState extends State<ConfigPage> {
   void initState() {
     super.initState();
     configController.fetchSubscriptions();
-    configController.checkAdFreeStatus();
   }
 
   @override

--- a/lib/app/modules/config/presenter/controller/config_controller.dart
+++ b/lib/app/modules/config/presenter/controller/config_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:cuber_timer/app/modules/config/presenter/services/purchase_service.dart';
-import 'package:cuber_timer/app/shared/services/app_review_service.dart';
 import 'package:injectable/injectable.dart';
 import 'package:mobx/mobx.dart';
 
@@ -16,11 +15,10 @@ class ConfigController = _ConfigControllerBase with _$ConfigController;
 
 abstract class _ConfigControllerBase with Store {
   final PurchaseService purchaseService;
-  final IAppReviewService appReviewService;
 
   late final StreamSubscription<PurchaseState> _purchaseSubscription;
 
-  _ConfigControllerBase(this.purchaseService, this.appReviewService) {
+  _ConfigControllerBase(this.purchaseService) {
     _purchaseSubscription =
         purchaseService.stream.listen(_onPurchaseStateChanged);
   }
@@ -31,20 +29,12 @@ abstract class _ConfigControllerBase with Store {
   @observable
   bool isPremium = false;
 
-  @observable
-  bool isRewardActive = false;
-
   @computed
-  bool get adsDisabled => isPremium || isRewardActive;
+  bool get adsDisabled => isPremium;
 
   String priceFor(SubscriptionPlan plan) => purchaseService.priceFor(plan);
 
   Future<void> buyPlan(SubscriptionPlan plan) => purchaseService.buy(plan);
-
-  @action
-  Future<void> checkAdFreeStatus() async {
-    isRewardActive = await appReviewService.isRewardActive();
-  }
 
   @action
   Future<void> fetchSubscriptions() async {

--- a/lib/app/modules/config/presenter/controller/config_controller.g.dart
+++ b/lib/app/modules/config/presenter/controller/config_controller.g.dart
@@ -49,30 +49,6 @@ mixin _$ConfigController on _ConfigControllerBase, Store {
     });
   }
 
-  late final _$isRewardActiveAtom =
-      Atom(name: '_ConfigControllerBase.isRewardActive', context: context);
-
-  @override
-  bool get isRewardActive {
-    _$isRewardActiveAtom.reportRead();
-    return super.isRewardActive;
-  }
-
-  @override
-  set isRewardActive(bool value) {
-    _$isRewardActiveAtom.reportWrite(value, super.isRewardActive, () {
-      super.isRewardActive = value;
-    });
-  }
-
-  late final _$checkAdFreeStatusAsyncAction =
-      AsyncAction('_ConfigControllerBase.checkAdFreeStatus', context: context);
-
-  @override
-  Future<void> checkAdFreeStatus() {
-    return _$checkAdFreeStatusAsyncAction.run(() => super.checkAdFreeStatus());
-  }
-
   late final _$fetchSubscriptionsAsyncAction =
       AsyncAction('_ConfigControllerBase.fetchSubscriptions', context: context);
 
@@ -87,7 +63,6 @@ mixin _$ConfigController on _ConfigControllerBase, Store {
     return '''
 state: ${state},
 isPremium: ${isPremium},
-isRewardActive: ${isRewardActive},
 adsDisabled: ${adsDisabled}
     ''';
   }

--- a/lib/app/modules/splash/presenter/splash_page.dart
+++ b/lib/app/modules/splash/presenter/splash_page.dart
@@ -29,7 +29,6 @@ class _SplashPageState extends State<SplashPage> {
   @override
   void initState() {
     super.initState();
-    configController.checkAdFreeStatus();
 
     _init();
   }

--- a/lib/app/shared/services/app_review_service.dart
+++ b/lib/app/shared/services/app_review_service.dart
@@ -3,17 +3,14 @@ import 'package:injectable/injectable.dart';
 
 import '../../core/data/clients/shared_preferences/adapters/shared_params.dart';
 import '../../core/data/clients/shared_preferences/local_storage_interface.dart';
-import '../../core/domain/entities/storage_keys.dart';
 
 abstract class IAppReviewService {
   Future<void> askReviewApp();
-  Future<bool> isRewardActive();
 }
 
 @Injectable(as: IAppReviewService)
 class AppReviewService implements IAppReviewService {
   static const String _counterKey = 'REVIEW_COUNTER';
-  static const String _rewardExpirationKey = StorageKeys.adFreeExpiration;
 
   final ILocalStorage localStorage;
   final InAppReview _inAppReview = InAppReview.instance;
@@ -39,24 +36,6 @@ class AppReviewService implements IAppReviewService {
       } else {
         await _inAppReview.openStoreListing();
       }
-
-      final expiration =
-          DateTime.now().add(const Duration(days: 7)).millisecondsSinceEpoch;
-
-      await localStorage.setData(
-        params: SharedParams(
-          key: _rewardExpirationKey,
-          value: expiration,
-        ),
-      );
     }
-  }
-
-  @override
-  Future<bool> isRewardActive() async {
-    final timestamp = await localStorage.getData(_rewardExpirationKey) as int?;
-    if (timestamp == null) return false;
-    final expiration = DateTime.fromMillisecondsSinceEpoch(timestamp);
-    return expiration.isAfter(DateTime.now());
   }
 }


### PR DESCRIPTION
## Summary
- remove lógica de recompensa e `isRewardActive`
- simplificar `ConfigController` para usar apenas `isPremium`
- atualizar injeção de dependência e páginas relacionadas

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(falhou: command not found)*
- `flutter test` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689002cd85788322ae0202163c3732c4