### PR TITLE
feat(config): add subscription descriptions and translations

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -42,3 +42,4 @@ config_page:
   plan_monthly: Monthly Plan
   plan_annual: Annual Plan
   button_subscribe: Subscribe
+  remove_ads_description: Remove ads from the app.

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -42,3 +42,4 @@ config_page:
   plan_monthly: Plano Mensal
   plan_annual: Plano Anual
   button_subscribe: Assinar
+  remove_ads_description: Remova anúncios do app.

--- a/lib/app/modules/config/presenter/config_page.dart
+++ b/lib/app/modules/config/presenter/config_page.dart
@@ -43,16 +43,19 @@ class _ConfigPageState extends State<ConfigPage> {
                 ),
               _buildPlanCard(
                 translate('config_page.plan_weekly'),
+                translate('config_page.remove_ads_description'),
                 purchaseService.priceFor(SubscriptionPlan.weekly),
                 onTap: () => purchaseService.buy(SubscriptionPlan.weekly),
               ),
               _buildPlanCard(
                 translate('config_page.plan_monthly'),
+                translate('config_page.remove_ads_description'),
                 purchaseService.priceFor(SubscriptionPlan.monthly),
                 onTap: () => purchaseService.buy(SubscriptionPlan.monthly),
               ),
               _buildPlanCard(
                 translate('config_page.plan_annual'),
+                translate('config_page.remove_ads_description'),
                 purchaseService.priceFor(SubscriptionPlan.annual),
                 onTap: () => purchaseService.buy(SubscriptionPlan.annual),
               ),
@@ -63,8 +66,12 @@ class _ConfigPageState extends State<ConfigPage> {
     );
   }
 
-  Widget _buildPlanCard(String title, String price,
-      {required VoidCallback onTap}) {
+  Widget _buildPlanCard(
+    String title,
+    String description,
+    String price, {
+    required VoidCallback onTap,
+  }) {
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8),
       child: ListTile(
@@ -72,7 +79,13 @@ class _ConfigPageState extends State<ConfigPage> {
           title,
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
-        subtitle: Text(price),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(description),
+            Text(price),
+          ],
+        ),
         trailing: ElevatedButton(
           onPressed: onTap,
           child: Text(translate('config_page.button_subscribe')),


### PR DESCRIPTION
## Summary
- show remove ads description on each subscription card
- translate remove ads description for English and Portuguese

## Testing
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689ff7e392a0832290a0c92b47a1c8ba