### PR TITLE
Add privacy and terms button

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -42,4 +42,5 @@ config_page:
   plan_monthly: Monthly Plan
   plan_annual: Annual Plan
   button_subscribe: Subscribe
+  button_privacy_terms: Privacy and Terms
   remove_ads_description: Remove ads from the app.

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -42,4 +42,5 @@ config_page:
   plan_monthly: Plano Mensal
   plan_annual: Plano Anual
   button_subscribe: Assinar
+  button_privacy_terms: Privacidade e Termos
   remove_ads_description: Remova anúncios do app.

--- a/lib/app/modules/config/presenter/config_page.dart
+++ b/lib/app/modules/config/presenter/config_page.dart
@@ -1,5 +1,6 @@
 import 'package:cuber_timer/app/shared/translate/translate.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../../core/domain/entities/subscription_plan.dart';
 import '../../../di/dependency_injection.dart';
@@ -14,6 +15,13 @@ class ConfigPage extends StatefulWidget {
 
 class _ConfigPageState extends State<ConfigPage> {
   final PurchaseService purchaseService = getIt<PurchaseService>();
+  final Uri _privacyUri = Uri.parse('https://lucas3g.github.io/#/');
+
+  Future<void> _openPrivacyTerms() async {
+    if (await canLaunchUrl(_privacyUri)) {
+      await launchUrl(_privacyUri, mode: LaunchMode.externalApplication);
+    }
+  }
 
   @override
   void initState() {
@@ -59,6 +67,13 @@ class _ConfigPageState extends State<ConfigPage> {
                 translate('config_page.remove_ads_description'),
                 purchaseService.priceFor(SubscriptionPlan.annual),
                 onTap: () => purchaseService.buy(SubscriptionPlan.annual),
+              ),
+              const SizedBox(height: 16),
+              TextButton(
+                onPressed: _openPrivacyTerms,
+                child: Text(
+                  translate('config_page.button_privacy_terms'),
+                ),
               ),
             ],
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   in_app_purchase: ^3.2.3
   super_sliver_list: ^0.4.1
   in_app_review: ^2.0.8
+  url_launcher: ^6.2.5
   flutter_localizations:
     sdk: flutter
   yaml: 3.1.3


### PR DESCRIPTION
## Summary
- add Privacy and Terms button on config page
- localize button label
- include url launcher dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b85251ece08322a0c6e175b74637e0