### PR TITLE
feat: improve empty records screen with subscription button

### DIFF
--- a/lib/app/modules/home/presenter/home_page.dart
+++ b/lib/app/modules/home/presenter/home_page.dart
@@ -270,9 +270,12 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Observer(builder: (context) {
+                  final Widget? subscriptionButton = _buildSubscriptionButton();
+
                   if (_tabController == null || sortedGroupedRecords.isEmpty) {
                     return NoDataWidget(
                       text: translate('home_page.list_empty'),
+                      child: subscriptionButton,
                     );
                   }
 
@@ -297,10 +300,9 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                   if (records.isEmpty) {
                     return NoDataWidget(
                       text: translate('home_page.list_empty'),
+                      child: subscriptionButton,
                     );
                   }
-
-                  final Widget? subscriptionButton = _buildSubscriptionButton();
 
                   return Expanded(
                     child: Column(

--- a/lib/app/shared/components/no_data_widget.dart
+++ b/lib/app/shared/components/no_data_widget.dart
@@ -5,9 +5,11 @@ import 'package:lottie/lottie.dart';
 
 class NoDataWidget extends StatelessWidget {
   final String text;
+  final Widget? child;
   const NoDataWidget({
     Key? key,
     required this.text,
+    this.child,
   }) : super(key: key);
 
   @override
@@ -29,6 +31,7 @@ class NoDataWidget extends StatelessWidget {
           const SizedBox(
             height: 10,
           ),
+          if (child != null) child!,
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- show subscribe button on empty record screen
- allow no-data widget to render optional actions

## Testing
- `dart format lib/app/shared/components/no_data_widget.dart lib/app/modules/home/presenter/home_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb7ead6888322a15e3132e844d322